### PR TITLE
add set_log_level RPC

### DIFF
--- a/src/app_rpc.c
+++ b/src/app_rpc.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/logging/log.h>
+#include <zephyr/logging/log_ctrl.h>
 LOG_MODULE_REGISTER(app_rpc, LOG_LEVEL_DBG);
 
 #include <net/golioth/system_client.h>
@@ -29,6 +30,44 @@ static void reboot_work_handler(struct k_work *work) {
 }
 K_WORK_DEFINE(reboot_work, reboot_work_handler);
 
+static enum golioth_rpc_status on_set_log_level(QCBORDecodeContext *request_params_array,
+					   QCBOREncodeContext *response_detail_map,
+					   void *callback_arg)
+{
+	double a;
+	uint32_t log_level;
+	QCBORError qerr;
+
+	QCBORDecode_GetDouble(request_params_array, &a);
+	qerr = QCBORDecode_GetError(request_params_array);
+	if (qerr != QCBOR_SUCCESS) {
+		LOG_ERR("Failed to decode array item: %d (%s)", qerr, qcbor_err_to_str(qerr));
+		return GOLIOTH_RPC_INVALID_ARGUMENT;
+	}
+
+	log_level = (uint32_t)a;
+
+	if ((log_level < 0) || (log_level > LOG_LEVEL_DBG)) {
+
+		LOG_ERR("Requested log level is out of bounds: %d", log_level);
+		return GOLIOTH_RPC_INVALID_ARGUMENT;
+	}
+
+	int source_id = 0;
+	char *source_name;
+	while(1) {
+		source_name = (char *)log_source_name_get(0, source_id);
+		if (source_name == NULL) {
+			break;
+		} else {
+			LOG_WRN("Settings %s log level to: %d", source_name, log_level);
+			log_filter_set(NULL, 0, source_id, log_level);
+			++source_id;
+		}
+	}
+	return GOLIOTH_RPC_OK;
+}
+
 static enum golioth_rpc_status on_reboot(QCBORDecodeContext *request_params_array,
 					   QCBOREncodeContext *response_detail_map,
 					   void *callback_arg)
@@ -38,12 +77,20 @@ static enum golioth_rpc_status on_reboot(QCBORDecodeContext *request_params_arra
 	return GOLIOTH_RPC_OK;
 }
 
-int app_register_rpc(struct golioth_client *rpc_client) {
-	int err = golioth_rpc_register(rpc_client, "reboot", on_reboot, NULL);
-
+static void rpc_log_if_register_failure(int err) {
 	if (err) {
 		LOG_ERR("Failed to register RPC: %d", err);
 	}
+}
+
+int app_register_rpc(struct golioth_client *rpc_client) {
+	int err;
+
+	err = golioth_rpc_register(rpc_client, "reboot", on_reboot, NULL);
+	rpc_log_if_register_failure(err);
+
+	err = golioth_rpc_register(rpc_client, "set_log_level", on_set_log_level, NULL);
+	rpc_log_if_register_failure(err);
 
 	return err;
 }


### PR DESCRIPTION
Sending a value [0..4] to the set_log_level RPC will reset the configured log level for all logging sources. This is a runtime setting and will revert to the compiled-in log level after the next power cycle.

Signed-off-by: Mike Szczys <mike@golioth.io>