### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2023 Golioth, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    - id: check-symlinks
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+      args: [--markdown-linebreak-ext=md]
+  - repo: https://github.com/cgnd/zephyr-pre-commit-hooks
+    rev: v0.1.2
+    hooks:
+    - id: zephyr-checkpatch

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Install the Python virtual environment (recommended)
    mkdir golioth-reference-design-template
    python -m venv golioth-reference-design-template/.venv
    source golioth-reference-design-template/.venv/bin/activate
-   pip install wheel west
+   pip install wheel west pre-commit
 
 Use ``west`` to initialize and install
 ======================================
@@ -36,9 +36,21 @@ Use ``west`` to initialize and install
    west update
    west zephyr-export
    pip install -r deps/zephyr/scripts/requirements.txt
+   source deps/zephyr/zephyr-env.sh
 
 This will also install the `golioth-zephyr-boards`_ definitions for the Golioth
 Aludel-Mini.
+
+Install ``pre-commit`` hooks
+============================
+
+This will install ``pre-commit`` hooks that will automatically check for simple
+issues before they are checked into the repo.
+
+.. code-block:: console
+
+   cd ~/golioth-reference-design-template/app
+   pre-commit install
 
 Building the application
 ************************

--- a/src/app_state.c
+++ b/src/app_state.c
@@ -161,4 +161,3 @@ void app_state_observe(void)
 		app_state_update_actual();
 	}
 }
-

--- a/src/app_work.c
+++ b/src/app_work.c
@@ -82,4 +82,3 @@ void app_work_init(struct golioth_client *work_client)
 {
 	client = work_client;
 }
-


### PR DESCRIPTION
Adds support for https://pre-commit.com which will automatically check for simple issues before they are checked into the repo.

For example, if I try to check in a `.gitignore` that doesn't have a trailing newline at the end of the file, pre-commit automatically prevents the commit from being committed and adds the missing newline for me:

```
check yaml...............................................................Passed
fix end of files.........................................................Failed
- hook id: end-of-file-fixer
- exit code: 1
- files were modified by this hook

Fixing .gitignore

trim trailing whitespace.................................................Passed
```

Checks enabled in this PR:
- [check-symlinks](https://github.com/pre-commit/pre-commit-hooks#check-symlinks)
- [check-yaml](https://github.com/pre-commit/pre-commit-hooks#check-yaml)
- [end-of-file-fixer](https://github.com/pre-commit/pre-commit-hooks#end-of-file-fixer)
- [trailing-whitespace](https://github.com/pre-commit/pre-commit-hooks#trailing-whitespace)
- [checkpatch](https://github.com/cgnd/zephyr-pre-commit-hooks#checkpatch)

Setup instructions:

1. Install pre-commit: https://pre-commit.com/#install
2. In the root directory of this repo, run `pre-commit install` to set up the hooks
3. (optional) run against all files to verify it's working `pre-commit run --all-files`