### PR TITLE
Update README with nRF9160 reset command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,7 @@ functionality on this Reference Design.
 
    $ (.venv) west build -b aludel_mini_v1_sparkfun9160_ns app -- -DCONFIG_MCUBOOT_IMAGE_VERSION=\"<your.semantic.version>\"
    $ (.venv) west flash
+   $ (.venv) nrfjprog -r
 
 Configure PSK-ID and PSK using the device shell based on your Golioth
 credentials and reboot:


### PR DESCRIPTION
For some reason, `west flash` doesn't reset the board. I need to run `nrfjprog -r` afterwards to reset the board (avoids having to manually push the reset button on the board).