### PR TITLE
Change template_* variables to app_*

### DIFF
--- a/src/app_state.c
+++ b/src/app_state.c
@@ -88,10 +88,10 @@ int app_state_desired_handler(struct golioth_req_rsp *rsp)
 
 	LOG_HEXDUMP_DBG(rsp->data, rsp->len, APP_STATE_DESIRED_ENDP);
 
-	struct template_state parsed_state;
+	struct app_state parsed_state;
 
 	int ret = json_obj_parse((char *)rsp->data, rsp->len,
-			template_state_descr, ARRAY_SIZE(template_state_descr),
+			app_state_descr, ARRAY_SIZE(app_state_descr),
 			&parsed_state);
 
 	if (ret < 0) {

--- a/src/json_helper.h
+++ b/src/json_helper.h
@@ -3,14 +3,14 @@
 
 #include <zephyr/data/json.h>
 
-struct template_state {
+struct app_state {
     int32_t example_int0;
     int32_t example_int1;
 };
 
-static const struct json_obj_descr template_state_descr[] = {
-    JSON_OBJ_DESCR_PRIM(struct template_state, example_int0, JSON_TOK_NUMBER),
-    JSON_OBJ_DESCR_PRIM(struct template_state, example_int1, JSON_TOK_NUMBER)
+static const struct json_obj_descr app_state_descr[] = {
+    JSON_OBJ_DESCR_PRIM(struct app_state, example_int0, JSON_TOK_NUMBER),
+    JSON_OBJ_DESCR_PRIM(struct app_state, example_int1, JSON_TOK_NUMBER)
 };
 
 #endif


### PR DESCRIPTION
@szczys I wanted to see what you thought about this.

Currently, when you fork a new reference design repo, you need to remember to change the app state variables from `template_*` to `my_rd_*`. This PR just changes those to `app_*` with the hope that they don't need to be changed at all when forking the repo.