### PR TITLE
Change golioth-led to led2 on nRF9160-DK board

### DIFF
--- a/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/boards/nrf9160dk_nrf9160_ns.overlay
@@ -2,6 +2,6 @@
 	aliases {
 		click-uart = &uart1;
 		click-i2c = &i2c2;
-		golioth-led = &led3;
+		golioth-led = &led2;
 	};
 };


### PR DESCRIPTION
When using the [Arduino UNO click shield](https://www.mikroe.com/arduino-uno-click-shield) for "unfolded" reference designs with the nRF9160-DK, the only nRF9160-DK LED who's corresponding GPIO isn't routed to a Click header pin is `LED2`.

<img width="587" alt="image" src="https://user-images.githubusercontent.com/14631/231675684-d37382fa-1804-4aef-b3f5-48207edf0bb7.png">
