### PR TITLE
battery_monitor: fix deprecated header include

### DIFF
--- a/src/battery_monitor/battery.c
+++ b/src/battery_monitor/battery.c
@@ -10,7 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/adc.h>


### PR DESCRIPTION
Include zephyr/kernel.h instead of zephyr/zephyr.h