### PR TITLE
Add missing include in battery header

### DIFF
--- a/src/battery_monitor/include/battery_monitor/battery.h
+++ b/src/battery_monitor/include/battery_monitor/battery.h
@@ -8,6 +8,8 @@
 #ifndef APPLICATION_BATTERY_H_
 #define APPLICATION_BATTERY_H_
 
+#include <zephyr/drivers/sensor.h>
+
 /** Enable or disable measurement of the battery voltage.
  *
  * @param enable true to enable, false to disable


### PR DESCRIPTION
Fixes this warning:

```
warning: 'struct sensor_value' declared inside parameter list will not be visible outside of this definition or declaration
   63 | int read_battery_info(struct sensor_value *batt_v, struct sensor_value *batt_lvl);
      |                              ^~~~~~~~~~~~
```