### PR TITLE
Use Arduino header DT node labels

### DIFF
--- a/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/boards/nrf9160dk_nrf9160_ns.overlay
@@ -1,7 +1,55 @@
 / {
 	aliases {
-		click-uart = &uart1;
-		click-i2c = &i2c2;
+		click-uart = &arduino_serial;
+		click-i2c = &arduino_i2c;
 		golioth-led = &led2;
+	};
+};
+
+&arduino_i2c {
+	/* Needed for I2C writes used by libostentus */
+	zephyr,concat-buf-size = <48>;
+};
+
+&pinctrl {
+	/*
+	 * Arduino Uno provides the same SCL/SDA on two sets of pins, but the
+	 * nRF9160-DK maps these pins to two different pairs of GPIO. When using
+	 * the Arduino Uno Click Shield board, the P0.18/P0.19 pair must be used.
+	 */
+	i2c2_default: i2c2_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 18)>,
+				<NRF_PSEL(TWIM_SCL, 0, 19)>;
+		};
+	};
+
+	i2c2_sleep: i2c2_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 18)>,
+				<NRF_PSEL(TWIM_SCL, 0, 19)>;
+			low-power-enable;
+		};
+	};
+
+	/*
+	 * The default pin group includes RTS/CTS HW flow control, but the Arduino
+	 * Uno Click Shield board does not connect these pins (only TX/RX are used).
+	 * This keeps RX/TX on the same pins, but just removes RTS/CTS from the
+	 * pin groups.
+	 */
+	uart1_default: uart1_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 1)>,
+				<NRF_PSEL(UART_RX, 0, 0)>;
+		};
+	};
+
+	uart1_sleep: uart1_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 1)>,
+				<NRF_PSEL(UART_RX, 0, 0)>;
+			low-power-enable;
+		};
 	};
 };


### PR DESCRIPTION
When I was looking into adding support for the nRF7002-DK, it occured to me that using the Arduino header node labels mihgt simplify making overlays for the DK family of boards. Each of the DK boards defines `arduino_serial`, `arduino_i2c`, `arduino_spi`, etc. like the following:

```
arduino_i2c: &i2c2 {
	...
};
```

By using `arduino_i2c` instead of `i2c2` in the app overlay, you can reuse the same definitions in the overlays.

For example, on the nRF9160-DK, you'd have to define:

```
		gnss7_sel: gnss7_sel {
			gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
		};
```

but on the nRF7002-DK, you'd have to define it differently:

```
		gnss7_sel: gnss7_sel {
			gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>;
		};
```

Since the `gnss7_sel` is routed to Arduino  header`A1` on all DK boards, you can instead use this same Arduino header definition for all DK boards:

```
		gnss7_sel: gnss7_sel {
			gpios = <&arduino_header 1 GPIO_ACTIVE_HIGH>; /* A1 */
		};
```

(you might even be able to just put this into a `dk-common.dtsi` file that gets included in each DK board overlay so there is no duplicated code)