### PR TITLE
Prebuilt binaries using GitHub Actions

### DIFF
--- a/.github/workflows/build_ncs.yml
+++ b/.github/workflows/build_ncs.yml
@@ -1,12 +1,14 @@
 name: Build binary for Nordic NCS
 
-# Runs when pushed to main, semver tagged release or any PR
+# Runs manually.
 on:
-  push:
-    branches: [ main ]
-    tags: [ 'v*.*.*' ]
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      mcuboot_image_version:
+        description: 'MCUboot Image Version.'
+        required: true
+        default: '0.0.0'
+        type: string
 
 jobs:
   build:
@@ -50,7 +52,7 @@ jobs:
           west update
           west zephyr-export
           pip3 install -r deps/zephyr/scripts/requirements.txt
-          west build -p -b ${{ matrix.BOARD }} app -- -DCONFIG_MCUBOOT_IMAGE_VERSION=\"0.0.0\"
+          west build -p -b ${{ matrix.BOARD }} app -- -DCONFIG_MCUBOOT_IMAGE_VERSION=\"${{ inputs.mcuboot_image_version }}\"
 
       - name: Create filename prefix
         run: echo "PREFIX=golioth-${{ github.event.repository.name }}-${{ matrix.BOARD }}" >> "$GITHUB_ENV"

--- a/.github/workflows/build_ncs.yml
+++ b/.github/workflows/build_ncs.yml
@@ -22,19 +22,19 @@ jobs:
       - name: Install OS dependencies
         run: >
           sudo apt-get install -y
+          cmake
           device-tree-compiler
           git
           ninja-build
           python3
           python3-pip
-          python3-wheel
           wget
           xz-utils
 
       - name: Install build tools
         run: |
           pip3 install wheel
-          pip3 install cmake west
+          pip3 install west
 
       - name: Install Zephyr SDK
         run: |

--- a/.github/workflows/build_ncs.yml
+++ b/.github/workflows/build_ncs.yml
@@ -51,8 +51,17 @@ jobs:
           west zephyr-export
           pip3 install -r deps/zephyr/scripts/requirements.txt
           west build -p -b ${{ matrix.BOARD }} app -- -DCONFIG_MCUBOOT_IMAGE_VERSION=\"0.0.0\"
-          mv build/zephyr/zephyr.bin build/zephyr/${{ matrix.BOARD }}.bin
-          mv build/zephyr/zephyr.elf build/zephyr/${{ matrix.BOARD }}.elf
+
+      - name: Create filename prefix
+        run: echo "PREFIX=golioth-${{ github.event.repository.name }}-${{ matrix.BOARD }}" >> "$GITHUB_ENV"
+
+      - name: Prepare artifacts
+        run: |
+          cd build/zephyr
+          mkdir -p artifacts
+          mv merged.hex     ./artifacts/${{ env.PREFIX }}_full_${GITHUB_SHA::7}.hex
+          mv app_update.bin ./artifacts/${{ env.PREFIX }}_update_${GITHUB_SHA::7}.bin
+          mv zephyr.elf     ./artifacts/${{ env.PREFIX }}_${GITHUB_SHA::7}.elf
 
       # Run IDs are unique per repo but are reused on re-runs
       - name: Save artifact
@@ -60,5 +69,4 @@ jobs:
         with:
           name: build_artifacts_${{ github.run_id }}
           path: |
-            build/zephyr/${{ matrix.BOARD }}.bin
-            build/zephyr/${{ matrix.BOARD }}.elf
+            build/zephyr/artifacts/*

--- a/.github/workflows/build_ncs.yml
+++ b/.github/workflows/build_ncs.yml
@@ -1,0 +1,64 @@
+name: Build binary for Nordic NCS
+
+# Runs when pushed to main, semver tagged release or any PR
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    # Uses matrix to test combinations. Update when SDK changes or to add new boards.
+    strategy:
+      matrix:
+        ZEPHYR_SDK_VERSION: [0.16.1]
+        BOARD: ["nrf9160dk_nrf9160_ns","aludel_mini_v1_sparkfun9160_ns"]
+
+    steps:
+      - name: Install OS dependencies
+        run: >
+          sudo apt-get install -y
+          device-tree-compiler
+          git
+          ninja-build
+          python3
+          python3-pip
+          python3-wheel
+          wget
+          xz-utils
+
+      - name: Install build tools
+        run: |
+          pip3 install wheel
+          pip3 install cmake west
+
+      - name: Install Zephyr SDK
+        run: |
+          wget -q "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${{ matrix.ZEPHYR_SDK_VERSION }}/zephyr-sdk-${{ matrix.ZEPHYR_SDK_VERSION }}_linux-x86_64_minimal.tar.xz"
+          mkdir -p /opt/zephyr-sdk
+          tar -xvf zephyr-sdk-${{ matrix.ZEPHYR_SDK_VERSION }}_linux-x86_64_minimal.tar.xz -C /opt/zephyr-sdk --strip-components=1
+          /opt/zephyr-sdk/setup.sh -t arm-zephyr-eabi
+          rm zephyr-sdk-${{ matrix.ZEPHYR_SDK_VERSION }}_linux-x86_64_minimal.tar.xz
+
+      - name: Build with West
+        run: |
+          west init -m https://github.com/$GITHUB_REPOSITORY .
+          west update
+          west zephyr-export
+          pip3 install -r deps/zephyr/scripts/requirements.txt
+          west build -p -b ${{ matrix.BOARD }} app -- -DCONFIG_MCUBOOT_IMAGE_VERSION=\"0.0.0\"
+          mv build/zephyr/zephyr.bin build/zephyr/${{ matrix.BOARD }}.bin
+          mv build/zephyr/zephyr.elf build/zephyr/${{ matrix.BOARD }}.elf
+
+      # Run IDs are unique per repo but are reused on re-runs
+      - name: Save artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: build_artifacts_${{ github.run_id }}
+          path: |
+            build/zephyr/${{ matrix.BOARD }}.bin
+            build/zephyr/${{ matrix.BOARD }}.elf


### PR DESCRIPTION
I've been working on GHA as a side project and think it would be useful to add prebuilt binaries automatically to reference designs. Some background and design designs:
* Separate yml files means we can target different flavors of RTOSes and/or different toolchains (ex. build_ncs.yml)
* Runs on `pushes` to main, semver tags or PRs
* Runs in a VM for speed
* Runs a test matrix across target Zephyr SDKs and boards
* Uses board name as binary name. This is to keep consistent names across build for later automation
* Bundles `.bin` and `.elf` in zip with a unique name per run

Future enhancement planned are using `git describe` in ZIP name, manual running of actions & Containers for more reproducible builds.

Closes #53