### PR TITLE
Ensure Ostentus is enabled before setting slides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix build error when `CONFIG_LIB_OSTENTUS=n` on the `aludel_mini_v1_sparkfun9160` board.
+
 ### Changed
 
 - Upgrade `golioth/golioth-zephyr-boards` dependency to [`v1.0.1`](https://github.com/golioth/golioth-zephyr-boards/tree/v1.0.1)

--- a/src/app_work.c
+++ b/src/app_work.c
@@ -44,8 +44,10 @@ void app_work_sensor_read(void)
 
 	IF_ENABLED(CONFIG_ALUDEL_BATTERY_MONITOR, (
 		read_and_report_battery();
-		slide_set(BATTERY_V, get_batt_v_str(), strlen(get_batt_v_str()));
-		slide_set(BATTERY_LVL, get_batt_lvl_str(), strlen(get_batt_lvl_str()));
+		IF_ENABLED(CONFIG_LIB_OSTENTUS, (
+			slide_set(BATTERY_V, get_batt_v_str(), strlen(get_batt_v_str()));
+			slide_set(BATTERY_LVL, get_batt_lvl_str(), strlen(get_batt_lvl_str()));
+		));
 	));
 
 	/* For this demo, we just send Hello to Golioth */


### PR DESCRIPTION
Not a common scenario, but I tried building for the `aludel_mini_v1_sparkfun9160` board with `CONFIG_LIB_OSTENTUS=n` and found a build error. This PR fixes the build error by ensuring that `CONFIG_LIB_OSTENTUS=y` before trying to set Ostentus slides.