### PR TITLE
battery_monitor: only stream if connected

### DIFF
--- a/src/battery_monitor/battery.c
+++ b/src/battery_monitor/battery.c
@@ -349,10 +349,12 @@ int read_and_report_battery(void)
 
 	log_battery_data();
 
-	err = stream_battery_data(&batt_data);
-	if (err) {
-		LOG_ERR("Error streaming battery info");
-		return err;
+	if (golioth_is_connected(client)) {
+		err = stream_battery_data(&batt_data);
+		if (err) {
+			LOG_ERR("Error streaming battery info");
+			return err;
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
Check for an active connection to Golioth before trying to stream battery readings from read_and_report_battery()