### PR TITLE
Use public Docker Hub image

### DIFF
--- a/.github/workflows/build_zephyr.yml
+++ b/.github/workflows/build_zephyr.yml
@@ -28,7 +28,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    container: ghcr.io/beriberikix/golioth-zephyr-base:${{ inputs.ZEPHYR_SDK }}sdk
+    container: golioth/golioth-zephyr-base:${{ inputs.ZEPHYR_SDK }}-SDK-v0
 
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-${{ inputs.ZEPHYR_SDK }}


### PR DESCRIPTION
Small update to use the newer Docker Hub images. Everything works the same and tested [here](https://github.com/beriberikix/reference-design-template/actions/runs/6806285964).