### PR TITLE
state: initialize err var to zero

### DIFF
--- a/src/app_state.c
+++ b/src/app_state.c
@@ -88,7 +88,7 @@ static void app_state_desired_handler(struct golioth_client *client,
 				      size_t payload_size,
 				      void *arg)
 {
-	int err;
+	int err = 0;
 	int ret;
 
 	if (response->status != GOLIOTH_OK) {


### PR DESCRIPTION
This err variable must be initializated to 0 to avoid triggering an error message when there has been no error. This reverts [a change made during the migration](https://github.com/golioth/reference-design-template/pull/72#discussion_r1496607462).