### PR TITLE
app_work: rename to app_sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade `golioth/golioth-zephyr-boards` dependency to [`v1.0.1`](https://github.com/golioth/golioth-zephyr-boards/tree/v1.0.1)
 - Dependencies use https instead of ssh GitHub URLs
 - libostentus removed from code base and included as a Zephyr module
+- renamed app_work.c/h to app_sensors.c/h
 
 ### Fixed
 - Fix build error when `CONFIG_LIB_OSTENTUS=n` on the `aludel_mini_v1_sparkfun9160` board.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,6 @@ target_sources(app PRIVATE src/main.c)
 target_sources(app PRIVATE src/app_rpc.c)
 target_sources(app PRIVATE src/app_settings.c)
 target_sources(app PRIVATE src/app_state.c)
-target_sources(app PRIVATE src/app_work.c)
+target_sources(app PRIVATE src/app_sensors.c)
 
 add_subdirectory_ifdef(CONFIG_ALUDEL_BATTERY_MONITOR src/battery_monitor)

--- a/src/app_sensors.c
+++ b/src/app_sensors.c
@@ -5,14 +5,14 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(app_work, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(app_sensors, LOG_LEVEL_DBG);
 
 #include <golioth/client.h>
 #include <golioth/stream.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/kernel.h>
 
-#include "app_work.h"
+#include "app_sensors.h"
 
 #ifdef CONFIG_LIB_OSTENTUS
 #include <libostentus.h>
@@ -42,7 +42,7 @@ static void async_error_handler(struct golioth_client *client,
 
 /* This will be called by the main() loop */
 /* Do all of your work here! */
-void app_work_sensor_read(void)
+void app_sensors_read_and_steam(void)
 {
 	int err;
 	char json_buf[256];
@@ -77,7 +77,7 @@ void app_work_sensor_read(void)
 	IF_ENABLED(CONFIG_LIB_OSTENTUS, (
 		/* Update slide values on Ostentus
 		 *  -values should be sent as strings
-		 *  -use the enum from app_work.h for slide key values
+		 *  -use the enum from app_sensors.h for slide key values
 		 */
 		snprintk(json_buf, sizeof(json_buf), "%d", counter);
 		slide_set(UP_COUNTER, json_buf, strlen(json_buf));
@@ -87,7 +87,7 @@ void app_work_sensor_read(void)
 	++counter;
 }
 
-void app_work_init(struct golioth_client *work_client)
+void app_sensors_init(struct golioth_client *work_client)
 {
 	client = work_client;
 }

--- a/src/app_sensors.h
+++ b/src/app_sensors.h
@@ -4,26 +4,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __APP_WORK_H__
-#define __APP_WORK_H__
+#ifndef __APP_SENSORS_H__
+#define __APP_SENSORS_H__
 
-/** The `app_work.c` file performs the important work of this application which
- * is to read sensor values and report them to the Golioth LightDB Stream as
- * time-series data.
+/** The `app_sensors.c` file performs the important work of this application
+ * which is to read sensor values and report them to the Golioth LightDB Stream
+ * as time-series data.
  *
  * For this demonstration, a `counter` value is periodically logged and pushed
  * to the Golioth time-series database. This simulated sensor reading occurs
- * when the loop in `main.c` calls `app_work_sensor_read()`. The frequency of
- * this loop is determined by values received from the Golioth Settings Service
- * (see app_settings.h).
+ * when the loop in `main.c` calls `app_sensors_read_and_steam()`. The frequency
+ * of this loop is determined by values received from the Golioth Settings
+ * Service (see app_settings.h).
  *
  * https://docs.golioth.io/firmware/zephyr-device-sdk/light-db-stream/
  */
 
 #include <golioth/client.h>
 
-void app_work_init(struct golioth_client *work_client);
-void app_work_sensor_read(void);
+void app_sensors_init(struct golioth_client *work_client);
+void app_sensors_read_and_steam(void);
 
 #define LABEL_UP_COUNTER "Counter"
 #define LABEL_DN_COUNTER "Anti-counter"
@@ -45,4 +45,4 @@ typedef enum {
 	FIRMWARE
 } slide_key;
 
-#endif /* __APP_WORK_H__ */
+#endif /* __APP_SENSORS_H__ */

--- a/src/app_state.c
+++ b/src/app_state.c
@@ -14,7 +14,7 @@ LOG_MODULE_REGISTER(app_state, LOG_LEVEL_DBG);
 #include "json_helper.h"
 
 #include "app_state.h"
-#include "app_work.h"
+#include "app_sensors.h"
 
 #define DEVICE_STATE_FMT "{\"example_int0\":%d,\"example_int1\":%d}"
 

--- a/src/battery_monitor/battery.c
+++ b/src/battery_monitor/battery.c
@@ -19,7 +19,7 @@
 #include <golioth/stream.h>
 
 #include "battery_monitor/battery.h"
-#include "../app_work.h"
+#include "../app_sensors.h"
 
 LOG_MODULE_REGISTER(battery, LOG_LEVEL_DBG);
 

--- a/src/main.c
+++ b/src/main.c
@@ -10,7 +10,7 @@ LOG_MODULE_REGISTER(golioth_rd_template, LOG_LEVEL_DBG);
 #include "app_rpc.h"
 #include "app_settings.h"
 #include "app_state.h"
-#include "app_work.h"
+#include "app_sensors.h"
 #include <golioth/client.h>
 #include <golioth/fw_update.h>
 #include <samples/common/net_connect.h>
@@ -87,7 +87,7 @@ static void start_golioth_client(void)
 	app_state_observe(client);
 
 	/* Initialize app work */
-	app_work_init(client);
+	app_sensors_init(client);
 
 	/* Register Settings service */
 	app_settings_register(client);
@@ -226,8 +226,8 @@ int main(void)
 	IF_ENABLED(CONFIG_LIB_OSTENTUS,(
 		/* Set up a slideshow on Ostentus
 		 *  - add up to 256 slides
-		 *  - use the enum in app_work.h to add new keys
-		 *  - values are updated using these keys (see app_work.c)
+		 *  - use the enum in app_sensors.h to add new keys
+		 *  - values are updated using these keys (see app_sensors.c)
 		 */
 		slide_add(UP_COUNTER, LABEL_UP_COUNTER, strlen(LABEL_UP_COUNTER));
 		slide_add(DN_COUNTER, LABEL_DN_COUNTER, strlen(LABEL_DN_COUNTER));
@@ -249,7 +249,7 @@ int main(void)
 	));
 
 	while (true) {
-		app_work_sensor_read();
+		app_sensors_read_and_steam();
 
 		k_sleep(K_SECONDS(get_loop_delay_s()));
 	}


### PR DESCRIPTION
The app_work.c/h files are mainly used for reading sensor data and sending on Golioth Stream. Changing the name to app_sensors.c/h will help users understand the purpose of the file.