### PR TITLE
settings: wake main thread after updating delay

### DIFF
--- a/src/app_settings.c
+++ b/src/app_settings.c
@@ -25,6 +25,7 @@ static enum golioth_settings_status on_loop_delay_setting(int32_t new_value, voi
 {
 	_loop_delay_s = new_value;
 	LOG_INF("Set loop delay to %i seconds", new_value);
+	wake_system_thread();
 	return GOLIOTH_SETTINGS_SUCCESS;
 }
 


### PR DESCRIPTION
When the LOOP_DELAY_S setting is updated, we need to wake the main thread which is currently sleeping based on the old delay value. This means you will have a sensor reading every time a new setting is received, but the point is for new setting to immediately take effect.