### PR TITLE
Fix truncated network info

### DIFF
--- a/prj.conf
+++ b/prj.conf
@@ -38,6 +38,8 @@ CONFIG_GOLIOTH_SAMPLE_SETTINGS_SHELL=y
 # Misc.
 CONFIG_JSON_LIBRARY=y
 CONFIG_NETWORK_INFO=y
+# Longer response length needed for network info
+CONFIG_GOLIOTH_RPC_MAX_RESPONSE_LEN=512
 CONFIG_I2C=y
 
 # Firmware version used in DFU process

--- a/west.yml
+++ b/west.yml
@@ -7,7 +7,7 @@ manifest:
   projects:
     - name: golioth
       path: modules/lib/golioth-firmware-sdk
-      revision: v0.11.0
+      revision: v0.11.1
       url: https://github.com/golioth/golioth-firmware-sdk.git
       west-commands: scripts/west-commands.yml
       submodules: true


### PR DESCRIPTION
Update Golioth to v0.11.0 and increase RPC return length.

Resolves #87 