### PR TITLE
network info: update version to newest release v1.1.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr-network-info
       path: deps/modules/lib/network-info
-      revision: v1.1.0
+      revision: v1.1.1
       url: https://github.com/golioth/zephyr-network-info
 
   self:


### PR DESCRIPTION
Update network info library for better zcbor encoding and more useful error messages.