### PR TITLE
Upgrade golioth-zephyr-boards dependency to v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
@@ -13,20 +14,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade `golioth/golioth-zephyr-boards` dependency to [`v1.2.0`](https://github.com/golioth/golioth-zephyr-boards/tree/v1.2.0).
 
-## [template_v2.2.1] 2024-05-31
+## [template_v2.2.1] - 2024-05-31
 
 ### Changed
 
 - Upgrade to Golioth Firmware SDK at v0.13.1
 
-## [template_v2.2.0] 2024-05-28
+## [template_v2.2.0] - 2024-05-28
 
 ### Changed
 
 - Upgrade to Golioth Firmware SDK at v0.13.0
 - Change `golioth_lightdb_observe_async()` call to include content type as a parameter
 
-## [template_v2.1.0] 2024-05-06
+## [template_v2.1.0] - 2024-05-06
 
 ### Added
 
@@ -58,9 +59,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 
 - Migrate to Golioth Firmware SDK at v0.10.0
-    - All header file and API call names have changed
-    - Many Golioth Kconfig symbols have changed
-    - OTA firmware update code is greatly simplified
+  - All header file and API call names have changed
+  - Many Golioth Kconfig symbols have changed
+  - OTA firmware update code is greatly simplified
 
 ### Added
 
@@ -70,18 +71,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Firmware version number is now passed as a symbol in the prj.conf file and not as a build argument
 - Use LTE Link handler from Golioth Common Library
-    - The majority of LTE Link handler callback is logging so this has been reused from the common
-      library
-    - An additional callback is registered in the application just to service on-connect events
+  - The majority of LTE Link handler callback is logging so this has been reused from the common
+    library
+  - An additional callback is registered in the application just to service on-connect events
 - Board definitions related to Ostentus face place moved to a common file that may be included when
   needed
 
 ## [template_v1.2.0] - 2023-11-08
 
 ### Added
+
 - GitHub workflow to create draft release and add compiled binaries to it.
 
 ### Changed
+
 - Update to most recent Golioth Zephyr SDK release v0.8.0 which uses:
   - nRF Connect SDK v2.5.0(NCS)
   - Zephyr v3.5.0
@@ -91,11 +94,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - renamed app_work.c/h to app_sensors.c/h
 
 ### Fixed
+
 - Fix build error when `CONFIG_LIB_OSTENTUS=n` on the `aludel_mini_v1_sparkfun9160` board.
 
 ## [template_v1.1.0] - 2023-08-18
 
 ### Breaking Changes
+
 - Golioth services (RPC, Settings, etc.) now use zcbor instead of qcbor
 - golioth-zephyr-boards repo now included as a module
   - Remove `golioth-boards` directory
@@ -107,6 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Remove `add_subdirectory(src/network_info)` from CMakeLists.txt
 
 ### Changed
+
 - update to most recent Golioth Zephyr SDK release v0.7.1 which uses:
   - nRF Connect SDK v2.4.1 (NCS)
   - Zephyr v3.3.99-ncs1-1
@@ -116,6 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   connection asynchronously
 
 ### Fixed
+
 - main.c: return int from main()
 - battery_monitor.c: use void as initialization param
 - main.c: use LOG_ERR() instead of printk() for button errors
@@ -123,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [template_v1.0.1] - 2023-07-14
 
 ### Fixed
+
 - Turn on Golioth LED when connected
 - Correctly reset `desired` endpoints when `example_int1` is changed by itself
 - Fix deadlock behavior when running `set_log_level` RPC multiple times
@@ -135,6 +143,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [template_v1.0.0] - 2023-07-11
 
 ### Added
+
 - Initial release
 - Support for aludel_mini_v1_sparkfun9160 (custom Golioth board)
 - Support for nrf9160dk_nrf9160_ns (commercially available)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Upgrade `golioth/golioth-zephyr-boards` dependency to [`v1.2.0`](https://github.com/golioth/golioth-zephyr-boards/tree/v1.2.0).
+
 ## [template_v2.2.1] 2024-05-31
 
 ### Changed

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ..
-   Copyright (c) 2022-2023 Golioth, Inc.
+   Copyright (c) 2024 Golioth, Inc.
    SPDX-License-Identifier: Apache-2.0
 
 Golioth Reference Design Template
@@ -16,8 +16,11 @@ implemented in basic form. Search the project for the word ``template`` and
 Local set up
 ************
 
-Do not clone this repo using git. Zephyr's ``west`` meta tool should be used to
-set up your local workspace.
+.. pull-quote::
+   [!IMPORTANT]
+
+   Do not clone this repo using git. Zephyr's ``west`` meta tool should be used to
+   set up your local workspace.
 
 Install the Python virtual environment (recommended)
 ====================================================
@@ -44,13 +47,13 @@ Use ``west`` to initialize and install
 Building the application
 ************************
 
-Build Zephyr sample application for Golioth Aludel-Mini
-(``aludel_mini_v1_sparkfun9160_ns``) from the top level of your project. After a
+Build the Zephyr sample application for the `Nordic nRF9160 DK`_
+(``nrf9160dk_nrf9160_ns``) from the top level of your project. After a
 successful build you will see a new ``build`` directory. Note that any changes
 (and git commits) to the project itself will be inside the ``app`` folder. The
 ``build`` and ``deps`` directories being one level higher prevents the repo from
 cataloging all of the changes to the dependencies and the build (so no
-``.gitignore`` is needed)
+``.gitignore`` is needed).
 
 Prior to building, update ``CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION`` in the ``prj.conf`` file to
 reflect the firmware version number you want to assign to this build. Then run the following
@@ -58,7 +61,7 @@ commands to build and program the firmware onto the device.
 
 .. code-block:: text
 
-   $ (.venv) west build -p -b aludel_mini_v1_sparkfun9160_ns app
+   $ (.venv) west build -p -b nrf9160dk_nrf9160_ns app
    $ (.venv) west flash
 
 Configure PSK-ID and PSK using the device shell based on your Golioth
@@ -146,18 +149,38 @@ explanation of this template.
 Hardware Variations
 *******************
 
-Nordic nRF9160 DK
-=================
-
-This reference design may be built for the `Nordic nRF9160 DK`_.
+This reference design may be built for a variety of different boards.
 
 Prior to building, update ``CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION`` in the ``prj.conf`` file to
 reflect the firmware version number you want to assign to this build. Then run the following
 commands to build and program the firmware onto the device.
 
+Golioth Aludel Mini
+===================
+
+This reference design may be built for the Golioth Aludel Mini board.
+
 .. code-block:: text
 
-   $ (.venv) west build -p -b nrf9160dk_nrf9160_ns app
+   $ (.venv) west build -p -b aludel_mini_v1_sparkfun9160_ns app
+   $ (.venv) west flash
+
+Golioth Aludel Elixir
+=====================
+
+This reference design may be built for the Golioth Aludel Elixir board. By default this will build
+for the latest hardware revision of this board.
+
+.. code-block:: text
+
+   $ (.venv) west build -p -b aludel_elixir_ns app
+   $ (.venv) west flash
+
+To build for a specific board revision (e.g. Rev A) add the revision suffix ``@<rev>``.
+
+.. code-block:: text
+
+   $ (.venv) west build -p -b aludel_elixir_ns@A app
    $ (.venv) west flash
 
 External Libraries

--- a/boards/aludel_elixir_ns.overlay
+++ b/boards/aludel_elixir_ns.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2024 Golioth, Inc.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&qwiic_i2c {
-	status = "okay";
-};

--- a/west.yml
+++ b/west.yml
@@ -33,7 +33,7 @@ manifest:
 
     - name: golioth-zephyr-boards
       path: deps/modules/lib/golioth-boards
-      revision: v1.1.1
+      revision: v1.2.0
       url: https://github.com/golioth/golioth-zephyr-boards
 
     - name: libostentus


### PR DESCRIPTION
In addition to adding build instructions for the Aludel Elixir board, this also updates the README build instructions to default to the nRF9160 DK board (since most customers don't have access to the Golioth boards).

There is a final commit in the series that fixes some of the CHANGELOG formatting to match the https://keepachangelog.com formatting.