### PR TITLE
libostentus: update to v2.0.0

### DIFF
--- a/boards/aludel_elixir_ns.conf
+++ b/boards/aludel_elixir_ns.conf
@@ -37,6 +37,3 @@ CONFIG_MODEM_INFO=y
 
 # Generate MCUboot compatible images
 CONFIG_BOOTLOADER_MCUBOOT=y
-
-# Use Golioth Ostentus Faceplate
-CONFIG_LIB_OSTENTUS=y

--- a/boards/aludel_elixir_ns.overlay
+++ b/boards/aludel_elixir_ns.overlay
@@ -1,0 +1,10 @@
+&i2c2 {
+    /* Needed for I2C writes used by libostentus */
+    zephyr,concat-buf-size = <48>;
+
+    ostentus@12 {
+        status = "okay";
+        compatible = "golioth,ostentus";
+        reg = <0x12>;
+    };
+};

--- a/boards/aludel_mini_v1_sparkfun9160_ns.conf
+++ b/boards/aludel_mini_v1_sparkfun9160_ns.conf
@@ -40,6 +40,3 @@ CONFIG_MODEM_INFO=y
 
 # Generate MCUboot compatible images
 CONFIG_BOOTLOADER_MCUBOOT=y
-
-# Use Golioth Ostentus Faceplate
-CONFIG_LIB_OSTENTUS=y

--- a/boards/aludel_mini_v1_sparkfun9160_ns.overlay
+++ b/boards/aludel_mini_v1_sparkfun9160_ns.overlay
@@ -1,0 +1,10 @@
+&i2c2 {
+    /* Needed for I2C writes used by libostentus */
+    zephyr,concat-buf-size = <48>;
+
+    ostentus@12 {
+        status = "okay";
+        compatible = "golioth,ostentus";
+        reg = <0x12>;
+    };
+};

--- a/src/app_sensors.c
+++ b/src/app_sensors.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(app_sensors, LOG_LEVEL_DBG);
 
 #ifdef CONFIG_LIB_OSTENTUS
 #include <libostentus.h>
+static const struct device *o_dev = DEVICE_DT_GET_ANY(golioth_ostentus);
 #endif
 #ifdef CONFIG_ALUDEL_BATTERY_MONITOR
 #include "battery_monitor/battery.h"
@@ -47,8 +48,14 @@ void app_sensors_read_and_stream(void)
 	IF_ENABLED(CONFIG_ALUDEL_BATTERY_MONITOR, (
 		read_and_report_battery(client);
 		IF_ENABLED(CONFIG_LIB_OSTENTUS, (
-			slide_set(BATTERY_V, get_batt_v_str(), strlen(get_batt_v_str()));
-			slide_set(BATTERY_LVL, get_batt_lvl_str(), strlen(get_batt_lvl_str()));
+			ostentus_slide_set(o_dev,
+					   BATTERY_V,
+					   get_batt_v_str(),
+					   strlen(get_batt_v_str()));
+			ostentus_slide_set(o_dev,
+					   BATTERY_LVL,
+					   get_batt_lvl_str(),
+					   strlen(get_batt_lvl_str()));
 		));
 	));
 
@@ -96,9 +103,9 @@ void app_sensors_read_and_stream(void)
 		char sbuf[32];
 
 		snprintk(sbuf, sizeof(sbuf), "%d", counter);
-		slide_set(UP_COUNTER, sbuf, strlen(sbuf));
+		ostentus_slide_set(o_dev, UP_COUNTER, sbuf, strlen(sbuf));
 		snprintk(sbuf, sizeof(sbuf), "%d", 65535 - counter);
-		slide_set(DN_COUNTER, sbuf, strlen(sbuf));
+		ostentus_slide_set(o_dev, DN_COUNTER, sbuf, strlen(sbuf));
 	));
 
 	/* Increment for the next run */

--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
 
     - name: libostentus
       path: deps/modules/lib/libostentus
-      revision: v1.0.0
+      revision: v2.0.0
       url: https://github.com/golioth/libostentus
 
     - name: zephyr-network-info


### PR DESCRIPTION
libostentus is now a Zephyr driver. Update the module version and change all API calls to match the driver syntax. Add reset and firmware version read when app first runs.

resolves https://github.com/golioth/devrel-issue-tracker/issues/442