### PR TITLE
use bash instead of sh so substitutions don't fail

### DIFF
--- a/.github/workflows/build_zephyr.yml
+++ b/.github/workflows/build_zephyr.yml
@@ -63,6 +63,7 @@ jobs:
           west build -p -b ${{ inputs.BOARD }} app
 
       - name: Prepare artifacts
+        shell: bash
         if: inputs.ARTIFACT == true && inputs.TAG != ''
 
         run: |


### PR DESCRIPTION
We need to substitute forward-slash for underscore when naming artifacts for the new Zephyr board names. The regex approach taken fails when using sh but will pass when the workflow is instructed to use bash.