### PR TITLE
app_sensors: only stream sensor data if connected

### DIFF
--- a/src/app_sensors.c
+++ b/src/app_sensors.c
@@ -28,8 +28,7 @@ static struct golioth_client *client;
 
 /* Callback for LightDB Stream */
 static void async_error_handler(struct golioth_client *client,
-				const struct golioth_response *response,
-				const char *path,
+				const struct golioth_response *response, const char *path,
 				void *arg)
 {
 	if (response->status != GOLIOTH_OK) {
@@ -68,10 +67,8 @@ void app_sensors_read_and_stream(void)
 
 	ZCBOR_STATE_E(zse, 1, cbor_buf, sizeof(cbor_buf), 1);
 
-	bool ok = zcbor_map_start_encode(zse, 1) &&
-		  zcbor_tstr_put_lit(zse, "counter") &&
-		  zcbor_uint32_put(zse, counter) &&
-		  zcbor_map_end_encode(zse, 1);
+	bool ok = zcbor_map_start_encode(zse, 1) && zcbor_tstr_put_lit(zse, "counter") &&
+		  zcbor_uint32_put(zse, counter) && zcbor_map_end_encode(zse, 1);
 
 	if (!ok) {
 		LOG_ERR("Failed to encode CBOR.");
@@ -83,13 +80,8 @@ void app_sensors_read_and_stream(void)
 	LOG_DBG("Streaming counter: %d", counter);
 
 	/* Stream data to Golioth */
-	err = golioth_stream_set_async(client,
-				       "sensor",
-				       GOLIOTH_CONTENT_TYPE_CBOR,
-				       cbor_buf,
-				       cbor_size,
-				       async_error_handler,
-				       NULL);
+	err = golioth_stream_set_async(client, "sensor", GOLIOTH_CONTENT_TYPE_CBOR, cbor_buf,
+				       cbor_size, async_error_handler, NULL);
 	if (err) {
 		LOG_ERR("Failed to send sensor data to Golioth: %d", err);
 	}

--- a/src/battery_monitor/battery.c
+++ b/src/battery_monitor/battery.c
@@ -311,8 +311,7 @@ void log_battery_data(void)
 }
 
 static void async_error_handler(struct golioth_client *client,
-				const struct golioth_response *response,
-				const char *path,
+				const struct golioth_response *response, const char *path,
 				void *arg)
 {
 	if (response->status != GOLIOTH_OK) {
@@ -333,13 +332,8 @@ int stream_battery_data(struct golioth_client *client, struct battery_data *batt
 		 batt_data->battery_level_pptt % 100);
 	LOG_DBG("%s", json_buf);
 
-	err = golioth_stream_set_async(client,
-				       stream_endpoint,
-				       GOLIOTH_CONTENT_TYPE_JSON,
-				       json_buf,
-				       strlen(json_buf),
-				       async_error_handler,
-				       NULL);
+	err = golioth_stream_set_async(client, stream_endpoint, GOLIOTH_CONTENT_TYPE_JSON, json_buf,
+				       strlen(json_buf), async_error_handler, NULL);
 	if (err) {
 		LOG_ERR("Failed to send battery data to Golioth: %d", err);
 	}

--- a/src/battery_monitor/battery.c
+++ b/src/battery_monitor/battery.c
@@ -365,6 +365,8 @@ int read_and_report_battery(struct golioth_client *client)
 			LOG_ERR("Error streaming battery info");
 			return err;
 		}
+	} else {
+		LOG_DBG("No connection available, skipping streaming battery info");
 	}
 
 	return 0;


### PR DESCRIPTION
When using LTE, we may start fetching sensor readings before a connection is established with Golioth. Readings can be shown on a local display during this period, but attempting to send to Golioth will fail. This updates the sensor reading streaming, which is just a counter in this case, to only attempt to stream readings to Golioth when connected. This mirrors the behavior of the battery monitor.

(ref for rationale on not blocking until connected: https://github.com/golioth/reference-design-template/pull/72/files#r1489688622)