### PR TITLE
workflows: bump action-upload to v4

### DIFF
--- a/.github/workflows/build_zephyr.yml
+++ b/.github/workflows/build_zephyr.yml
@@ -49,6 +49,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: app
+
+      - name: Process Board name
+        id: nicename
+        shell: bash
+        run: |
+          BOARD_NICENAME=${{ inputs.BOARD }}
+          BOARD_NICENAME=${BOARD_NICENAME//\//_}
+          echo "BOARD_NICENAME=${BOARD_NICENAME}" >> $GITHUB_OUTPUT
+
       - name: Setup West workspace
         run: |
           west init -l app
@@ -69,17 +78,15 @@ jobs:
         run: |
           cd build
           mkdir -p artifacts
-          BOARD_NICENAME=${{ inputs.BOARD }}
-          BOARD_NICENAME=${BOARD_NICENAME//\//_}
-          mv merged.hex                   ./artifacts/golioth-${{ github.event.repository.name }}_${{ inputs.TAG }}_${BOARD_NICENAME}_full.hex
-          mv app/zephyr/zephyr.signed.bin ./artifacts/golioth-${{ github.event.repository.name }}_${{ inputs.TAG }}_${BOARD_NICENAME}_update.bin
-          mv app/zephyr/zephyr.elf        ./artifacts/golioth-${{ github.event.repository.name }}_${{ inputs.TAG }}_${BOARD_NICENAME}.elf
+          mv merged.hex                   ./artifacts/golioth-${{ github.event.repository.name }}_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}_full.hex
+          mv app/zephyr/zephyr.signed.bin ./artifacts/golioth-${{ github.event.repository.name }}_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}_update.bin
+          mv app/zephyr/zephyr.elf        ./artifacts/golioth-${{ github.event.repository.name }}_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}.elf
 
       # Run IDs are unique per repo but are reused on re-runs
       - name: Save artifact
         if: inputs.ARTIFACT == true
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: build_artifacts_${{ github.run_id }}
+          name: build_artifacts_${{ github.run_id }}_${{ steps.nicename.outputs.BOARD_NICENAME }}
           path: |
             build/artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,9 @@ jobs:
             - name: Download artifact
               uses: actions/download-artifact@v4
               with:
-                name: build_artifacts_${{ github.run_id }}
+                pattern: build_artifacts_*
                 path: ~/artifacts
+                merge-multiple: true
 
             - name: Create Release manually with GH CLI
               run: gh release create --title ${{ inputs.version }} --draft ${{ inputs.version }}


### PR DESCRIPTION
The new version of upload artifact disallows repeat upload to the same directory. Instead, artifacts should be uploaded using unique names, then gathered into a single archive using the merge and pattern parameters.