### PR TITLE
Reorganize readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ data to simulate senor readings, and sends Log messages to the cloud.
 From the Golioth web console you may deploy OTA firmware updates, adjust
 device Settings, and issue Remote Procedure Calls (RPCs).
 
+Business use cases and hardware build details for Golioth Reference
+Designs are available on the [Golioth Projects
+site](https://projects.golioth.io/).
+
 Use this repo as a template when beginning work on a new Golioth
 Reference Design. It is set up as a standalone repository, with all
 Golioth features implemented in basic form. Search the project for the

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ reference design's name.
 ## Golioth Features
 
 This app currently implements Over-the-Air (OTA) firmware updates,
-Settings Service, Logging, RPC, and both LightDB State and LightDB
-Stream data.
+Settings Service, Logging, RPC, and time-series Stream data, and LightDB
+State data.
 
 ### Settings Service
 

--- a/README.md
+++ b/README.md
@@ -58,28 +58,50 @@ the [Golioth Console](https://console.golioth.io).
       - `3`: `LOG_LEVEL_INF`
       - `4`: `LOG_LEVEL_DBG`
 
-## LightDB State and LightDB Stream data
+## Time-Series Stream data
 
-### Time-Series Data (LightDB Stream)
+Sensor readings are simulated using an up-counting timer. The value is
+periodically sent to the `sensor/counter` path of the Golioth Stream
+service.
 
-An up-counting timer is periodically sent to the `sensor/counter`
-endpoint of the LightDB Stream service to simulate sensor data. If your
-board includes a battery, voltage and level readings will be sent to the
-`battery` endpoint.
+``` json
+{
+  "counter": 1
+}
+```
+
+If your board includes a battery, voltage and level readings
+will be sent to the `battery` path.
 
 ### Stateful Data (LightDB State)
 
 The concept of Digital Twin is demonstrated with the LightDB State
-`example_int0` and `example_int1` variables that are members of the
-`desired` and `state` endpoints.
+`example_int0` and `example_int1` variables that are subpaths of the
+`desired` and `state` paths.
 
   - `desired` values may be changed from the cloud side. The device will
     recognize these, validate them for \[0..65535\] bounding, and then
-    reset these endpoints to `-1`
-  - `state` values will be updated by the device whenever a valid value
-    is received from the `desired` endpoints. The cloud may read the
-    `state` endpoints to determine device status, but only the device
+    reset these values to `-1`
+  - `state` values will be updated by the device to reflect the device's
+    actual stored value. The cloud may read the `state` endpoints to
+    determine device status. In this arrangement, only the device
     should ever write to the `state` endpoints.
+
+``` json
+{
+  "desired": {
+    "example_int0": -1,
+    "example_int1": -1
+  },
+  "state": {
+    "example_int0": 0,
+    "example_int1": 1
+  }
+}
+```
+
+But default the state values will be `0` and `1`. Try updating the
+`desired` values and observe how the device updates its state.
 
 ## OTA Firmware Update
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Golioth features implemented in basic form. Search the project for the
 word `template` and `rd_template` and update those occurrences with your
 reference design's name.
 
+# Supported Hardware
+
+- Nordic nRF9160-DK
+- Golioth Aludel Elixir
+- Golioth Aludel Mini
+
 # Local set up
 
 > Do not clone this repo using git. Zephyr's `west` meta tool should be

--- a/README.md
+++ b/README.md
@@ -18,89 +18,6 @@ reference design's name.
 - Golioth Aludel Elixir
 - Golioth Aludel Mini
 
-# Local set up
-
-> Do not clone this repo using git. Zephyr's `west` meta tool should be
-> used to set up your local workspace.
-
-## Install the Python virtual environment (recommended)
-
-``` shell
-cd ~
-mkdir golioth-reference-design-template
-python -m venv golioth-reference-design-template/.venv
-source golioth-reference-design-template/.venv/bin/activate
-pip install wheel west ecdsa
-```
-
-## Use `west` to initialize and install
-
-``` shell
-cd ~/golioth-reference-design-template
-west init -m git@github.com:golioth/reference-design-template.git .
-west update
-west zephyr-export
-pip install -r deps/zephyr/scripts/requirements.txt
-```
-
-# Building the application
-
-Build the Zephyr sample application for the [Nordic nRF9160
-DK](https://www.nordicsemi.com/Products/Development-hardware/nrf9160-dk)
-(`nrf9160dk_nrf9160_ns`) from the top level of your project. After a
-successful build you will see a new `build` directory. Note that any
-changes (and git commits) to the project itself will be inside the `app`
-folder. The `build` and `deps` directories being one level higher
-prevents the repo from cataloging all of the changes to the dependencies
-and the build (so no `.gitignore` is needed).
-
-Prior to building, update `VERSION` file to reflect the firmware version
-number you want to assign to this build. Then run the following commands
-to build and program the firmware onto the device.
-
-> You must perform a pristine build (use `-p` or remove the `build`
-> directory) after changing the firmware version number in the `VERSION`
-> file for the change to take effect.
-
-``` text
-$ (.venv) west build -p -b nrf9160dk/nrf9160/ns --sysbuild app
-$ (.venv) west flash
-```
-
-Configure PSK-ID and PSK using the device shell based on your Golioth
-credentials and reboot:
-
-``` text
-uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
-uart:~$ settings set golioth/psk <my-psk>
-uart:~$ kernel reboot cold
-```
-
-# Add Pipeline to Golioth
-
-Golioth uses [Pipelines](https://docs.golioth.io/data-routing) to route
-stream data. This gives you flexibility to change your data routing
-without requiring updated device firmware.
-
-Whenever sending stream data, you must enable a pipeline in your Golioth
-project to configure how that data is handled. Add the contents of
-`pipelines/cbor-to-lightdb.yml` as a new pipeline as follows (note that
-this is the default pipeline for new projects and may already be
-present):
-
-1.  Navigate to your project on the Golioth web console.
-2.  Select `Pipelines` from the left sidebar and click the `Create`
-    button.
-3.  Give your new pipeline a name and paste the pipeline configuration
-    into the editor.
-4.  Click the toggle in the bottom right to enable the pipeline and
-    then click `Create`.
-
-All data streamed to Golioth in CBOR format will now be routed to
-LightDB Stream and may be viewed using the web console. You may change
-this behavior at any time without updating firmware simply by editing
-this pipeline entry.
-
 # Golioth Features
 
 This app currently implements Over-the-Air (OTA) firmware updates,
@@ -164,10 +81,53 @@ The concept of Digital Twin is demonstrated with the LightDB State
     `state` endpoints to determine device status, but only the device
     should ever write to the `state` endpoints.
 
+## OTA Firmware Update
+
+This application includes the ability to perform Over-the-Air (OTA)
+firmware updates:
+
+1.  Update the version number in the
+    <span class="title-ref">VERSION</span> file and perform a pristine
+    (important) build to incorporate the version change.
+2.  Upload the
+    <span class="title-ref">build/app/zephyr/zephyr.signed.bin</span>
+    file as an artifact for your Golioth project using
+    <span class="title-ref">main</span> as the package name.
+3.  Create and roll out a release based on this artifact.
+
+Visit [the Golioth Docs OTA Firmware Upgrade
+page](https://docs.golioth.io/firmware/golioth-firmware-sdk/firmware-upgrade/firmware-upgrade)
+for more info.
+
 ## Further Information in Header Files
 
 Please refer to the comments in each header file for a
 service-by-service explanation of this template.
+
+# Local set up
+
+> Do not clone this repo using git. Zephyr's `west` meta tool should be
+> used to set up your local workspace.
+
+## Install the Python virtual environment (recommended)
+
+``` shell
+cd ~
+mkdir golioth-reference-design-template
+python -m venv golioth-reference-design-template/.venv
+source golioth-reference-design-template/.venv/bin/activate
+pip install wheel west ecdsa
+```
+
+## Use `west` to initialize and install
+
+``` shell
+cd ~/golioth-reference-design-template
+west init -m git@github.com:golioth/reference-design-template.git .
+west update
+west zephyr-export
+pip install -r deps/zephyr/scripts/requirements.txt
+```
 
 # Hardware Variations
 
@@ -205,23 +165,63 @@ $ (.venv) west build -p -b aludel_elixir@A/nrf9160/ns --sysbuild app
 $ (.venv) west flash
 ```
 
-# OTA Firmware Update
+# Building the application
 
-This application includes the ability to perform Over-the-Air (OTA)
-firmware updates:
+Build the Zephyr sample application for the [Nordic nRF9160
+DK](https://www.nordicsemi.com/Products/Development-hardware/nrf9160-dk)
+(`nrf9160dk_nrf9160_ns`) from the top level of your project. After a
+successful build you will see a new `build` directory. Note that any
+changes (and git commits) to the project itself will be inside the `app`
+folder. The `build` and `deps` directories being one level higher
+prevents the repo from cataloging all of the changes to the dependencies
+and the build (so no `.gitignore` is needed).
 
-1.  Update the version number in the
-    <span class="title-ref">VERSION</span> file and perform a pristine
-    (important) build to incorporate the version change.
-2.  Upload the
-    <span class="title-ref">build/app/zephyr/zephyr.signed.bin</span>
-    file as an artifact for your Golioth project using
-    <span class="title-ref">main</span> as the package name.
-3.  Create and roll out a release based on this artifact.
+Prior to building, update `VERSION` file to reflect the firmware version
+number you want to assign to this build. Then run the following commands
+to build and program the firmware onto the device.
 
-Visit [the Golioth Docs OTA Firmware Upgrade
-page](https://docs.golioth.io/firmware/golioth-firmware-sdk/firmware-upgrade/firmware-upgrade)
-for more info.
+> You must perform a pristine build (use `-p` or remove the `build`
+> directory) after changing the firmware version number in the `VERSION`
+> file for the change to take effect.
+
+``` text
+$ (.venv) west build -p -b nrf9160dk/nrf9160/ns --sysbuild app
+$ (.venv) west flash
+```
+
+Configure PSK-ID and PSK using the device shell based on your Golioth
+credentials and reboot:
+
+``` text
+uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
+uart:~$ settings set golioth/psk <my-psk>
+uart:~$ kernel reboot cold
+```
+
+# Add Pipeline to Golioth
+
+Golioth uses [Pipelines](https://docs.golioth.io/data-routing) to route
+stream data. This gives you flexibility to change your data routing
+without requiring updated device firmware.
+
+Whenever sending stream data, you must enable a pipeline in your Golioth
+project to configure how that data is handled. Add the contents of
+`pipelines/cbor-to-lightdb.yml` as a new pipeline as follows (note that
+this is the default pipeline for new projects and may already be
+present):
+
+1.  Navigate to your project on the Golioth web console.
+2.  Select `Pipelines` from the left sidebar and click the `Create`
+    button.
+3.  Give your new pipeline a name and paste the pipeline configuration
+    into the editor.
+4.  Click the toggle in the bottom right to enable the pipeline and
+    then click `Create`.
+
+All data streamed to Golioth in CBOR format will now be routed to
+LightDB Stream and may be viewed using the web console. You may change
+this behavior at any time without updating firmware simply by editing
+this pipeline entry.
 
 # External Libraries
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ service.
 If your board includes a battery, voltage and level readings
 will be sent to the `battery` path.
 
+> Note: your Golioth project must have a Pipeline enabled to receive
+> this data. See the [Add Pipeline to Golioth](#add-pipeline-to-golioth)
+> section below.
+
 ### Stateful Data (LightDB State)
 
 The concept of Digital Twin is demonstrated with the LightDB State
@@ -136,6 +140,31 @@ for more info.
 Please refer to the comments in each header file for a
 service-by-service explanation of this template.
 
+# Add Pipeline to Golioth
+
+Golioth uses [Pipelines](https://docs.golioth.io/data-routing) to route
+stream data. This gives you flexibility to change your data routing
+without requiring updated device firmware.
+
+Whenever sending stream data, you must enable a pipeline in your Golioth
+project to configure how that data is handled. Add the contents of
+`pipelines/cbor-to-lightdb.yml` as a new pipeline as follows (note that
+this is the default pipeline for new projects and may already be
+present):
+
+1.  Navigate to your project on the Golioth web console.
+2.  Select `Pipelines` from the left sidebar and click the `Create`
+    button.
+3.  Give your new pipeline a name and paste the pipeline configuration
+    into the editor.
+4.  Click the toggle in the bottom right to enable the pipeline and
+    then click `Create`.
+
+All data streamed to Golioth in CBOR format will now be routed to
+LightDB Stream and may be viewed using the web console. You may change
+this behavior at any time without updating firmware simply by editing
+this pipeline entry.
+
 # Local set up
 
 > Do not clone this repo using git. Zephyr's `west` meta tool should be
@@ -159,42 +188,6 @@ west init -m git@github.com:golioth/reference-design-template.git .
 west update
 west zephyr-export
 pip install -r deps/zephyr/scripts/requirements.txt
-```
-
-# Hardware Variations
-
-This reference design may be built for a variety of different boards.
-
-Prior to building, update `VERSION` file to reflect the firmware version
-number you want to assign to this build. Then run the following commands
-to build and program the firmware onto the device.
-
-## Golioth Aludel Mini
-
-This reference design may be built for the Golioth Aludel Mini board.
-
-``` text
-$ (.venv) west build -p -b aludel_mini/nrf9160/ns --sysbuild app
-$ (.venv) west flash
-```
-
-## Golioth Aludel Elixir
-
-This reference design may be built for the Golioth Aludel Elixir board.
-By default this will build for the latest hardware revision of this
-board.
-
-``` text
-$ (.venv) west build -p -b aludel_elixir/nrf9160/ns --sysbuild app
-$ (.venv) west flash
-```
-
-To build for a specific board revision (e.g. Rev A) add the revision
-suffix `@<rev>`.
-
-``` text
-$ (.venv) west build -p -b aludel_elixir@A/nrf9160/ns --sysbuild app
-$ (.venv) west flash
 ```
 
 # Building the application
@@ -230,30 +223,37 @@ uart:~$ settings set golioth/psk <my-psk>
 uart:~$ kernel reboot cold
 ```
 
-# Add Pipeline to Golioth
+# Hardware Variations
 
-Golioth uses [Pipelines](https://docs.golioth.io/data-routing) to route
-stream data. This gives you flexibility to change your data routing
-without requiring updated device firmware.
+This reference design may be built for a variety of different boards.
 
-Whenever sending stream data, you must enable a pipeline in your Golioth
-project to configure how that data is handled. Add the contents of
-`pipelines/cbor-to-lightdb.yml` as a new pipeline as follows (note that
-this is the default pipeline for new projects and may already be
-present):
+## Golioth Aludel Mini
 
-1.  Navigate to your project on the Golioth web console.
-2.  Select `Pipelines` from the left sidebar and click the `Create`
-    button.
-3.  Give your new pipeline a name and paste the pipeline configuration
-    into the editor.
-4.  Click the toggle in the bottom right to enable the pipeline and
-    then click `Create`.
+This reference design may be built for the Golioth Aludel Mini board.
 
-All data streamed to Golioth in CBOR format will now be routed to
-LightDB Stream and may be viewed using the web console. You may change
-this behavior at any time without updating firmware simply by editing
-this pipeline entry.
+``` text
+$ (.venv) west build -p -b aludel_mini/nrf9160/ns --sysbuild app
+$ (.venv) west flash
+```
+
+## Golioth Aludel Elixir
+
+This reference design may be built for the Golioth Aludel Elixir board.
+By default this will build for the latest hardware revision of this
+board.
+
+``` text
+$ (.venv) west build -p -b aludel_elixir/nrf9160/ns --sysbuild app
+$ (.venv) west flash
+```
+
+To build for a specific board revision (e.g. Rev A) add the revision
+suffix `@<rev>`.
+
+``` text
+$ (.venv) west build -p -b aludel_elixir@A/nrf9160/ns --sysbuild app
+$ (.venv) west flash
+```
 
 # External Libraries
 

--- a/README.md
+++ b/README.md
@@ -232,38 +232,6 @@ uart:~$ settings set golioth/psk <my-psk>
 uart:~$ kernel reboot cold
 ```
 
-## Hardware Variations
-
-This reference design may be built for a variety of different boards.
-
-### Golioth Aludel Mini
-
-This reference design may be built for the Golioth Aludel Mini board.
-
-``` text
-$ (.venv) west build -p -b aludel_mini/nrf9160/ns --sysbuild app
-$ (.venv) west flash
-```
-
-### Golioth Aludel Elixir
-
-This reference design may be built for the Golioth Aludel Elixir board.
-By default this will build for the latest hardware revision of this
-board.
-
-``` text
-$ (.venv) west build -p -b aludel_elixir/nrf9160/ns --sysbuild app
-$ (.venv) west flash
-```
-
-To build for a specific board revision (e.g. Rev A) add the revision
-suffix `@<rev>`.
-
-``` text
-$ (.venv) west build -p -b aludel_elixir@A/nrf9160/ns --sysbuild app
-$ (.venv) west flash
-```
-
 ## External Libraries
 
 The following code libraries are installed by default. If you are not

--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ Golioth features implemented in basic form. Search the project for the
 word `template` and `rd_template` and update those occurrences with your
 reference design's name.
 
-# Supported Hardware
+## Supported Hardware
 
 - Nordic nRF9160-DK
 - Golioth Aludel Elixir
 - Golioth Aludel Mini
 
-# Golioth Features
+## Golioth Features
 
 This app currently implements Over-the-Air (OTA) firmware updates,
 Settings Service, Logging, RPC, and both LightDB State and LightDB
 Stream data.
 
-## Settings Service
+### Settings Service
 
 The following settings should be set in the Device Settings menu of the
 [Golioth Console](https://console.golioth.io).
@@ -35,7 +35,7 @@ The following settings should be set in the Device Settings menu of the
 
     Default value is `60` seconds.
 
-## Remote Procedure Call (RPC) Service
+### Remote Procedure Call (RPC) Service
 
 The following RPCs can be initiated in the Remote Procedure Call menu of
 the [Golioth Console](https://console.golioth.io).
@@ -58,7 +58,7 @@ the [Golioth Console](https://console.golioth.io).
       - `3`: `LOG_LEVEL_INF`
       - `4`: `LOG_LEVEL_DBG`
 
-## Time-Series Stream data
+### Time-Series Stream data
 
 Sensor readings are simulated using an up-counting timer. The value is
 periodically sent to the `sensor/counter` path of the Golioth Stream
@@ -107,7 +107,7 @@ The concept of Digital Twin is demonstrated with the LightDB State
 But default the state values will be `0` and `1`. Try updating the
 `desired` values and observe how the device updates its state.
 
-## OTA Firmware Update
+### OTA Firmware Update
 
 This application includes the ability to perform Over-the-Air (OTA)
 firmware updates. To do so, you need a binary compiled with a different
@@ -135,12 +135,12 @@ Visit [the Golioth Docs OTA Firmware Upgrade
 page](https://docs.golioth.io/firmware/golioth-firmware-sdk/firmware-upgrade/firmware-upgrade)
 for more info.
 
-## Further Information in Header Files
+### Further Information in Header Files
 
 Please refer to the comments in each header file for a
 service-by-service explanation of this template.
 
-# Add Pipeline to Golioth
+## Add Pipeline to Golioth
 
 Golioth uses [Pipelines](https://docs.golioth.io/data-routing) to route
 stream data. This gives you flexibility to change your data routing
@@ -165,12 +165,12 @@ LightDB Stream and may be viewed using the web console. You may change
 this behavior at any time without updating firmware simply by editing
 this pipeline entry.
 
-# Local set up
+## Local set up
 
 > Do not clone this repo using git. Zephyr's `west` meta tool should be
 > used to set up your local workspace.
 
-## Install the Python virtual environment (recommended)
+### Install the Python virtual environment (recommended)
 
 ``` shell
 cd ~
@@ -180,7 +180,7 @@ source golioth-reference-design-template/.venv/bin/activate
 pip install wheel west ecdsa
 ```
 
-## Use `west` to initialize and install
+### Use `west` to initialize and install
 
 ``` shell
 cd ~/golioth-reference-design-template
@@ -190,7 +190,7 @@ west zephyr-export
 pip install -r deps/zephyr/scripts/requirements.txt
 ```
 
-# Building the application
+## Building the application
 
 Build the Zephyr sample application for the [Nordic nRF9160
 DK](https://www.nordicsemi.com/Products/Development-hardware/nrf9160-dk)
@@ -223,11 +223,11 @@ uart:~$ settings set golioth/psk <my-psk>
 uart:~$ kernel reboot cold
 ```
 
-# Hardware Variations
+## Hardware Variations
 
 This reference design may be built for a variety of different boards.
 
-## Golioth Aludel Mini
+### Golioth Aludel Mini
 
 This reference design may be built for the Golioth Aludel Mini board.
 
@@ -236,7 +236,7 @@ $ (.venv) west build -p -b aludel_mini/nrf9160/ns --sysbuild app
 $ (.venv) west flash
 ```
 
-## Golioth Aludel Elixir
+### Golioth Aludel Elixir
 
 This reference design may be built for the Golioth Aludel Elixir board.
 By default this will build for the latest hardware revision of this
@@ -255,7 +255,7 @@ $ (.venv) west build -p -b aludel_elixir@A/nrf9160/ns --sysbuild app
 $ (.venv) west flash
 ```
 
-# External Libraries
+## External Libraries
 
 The following code libraries are installed by default. If you are not
 using the custom hardware to which they apply, you can safely remove
@@ -270,7 +270,7 @@ calls from the C code.
     is a helper library for querying, formatting, and returning network
     connection information via Zephyr log or Golioth RPC
 
-# Using this template to start a new project
+## Using this template to start a new project
 
 Fork this template to create your own Reference Design. After checking
 out your fork, we recommend the following workflow to pull in future

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Overview
 
+The Reference Design Template demonstrates Golioth Device Management and
+Data Routing. The application connects to Golioth, streams time-series
+data to simulate senor readings, and sends Log messages to the cloud.
+From the Golioth web console you may deploy OTA firmware updates, adjust
+device Settings, and issue Remote Procedure Calls (RPCs).
+
 Use this repo as a template when beginning work on a new Golioth
 Reference Design. It is set up as a standalone repository, with all
 Golioth features implemented in basic form. Search the project for the

--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ service.
 If your board includes a battery, voltage and level readings
 will be sent to the `battery` path.
 
-> Note: your Golioth project must have a Pipeline enabled to receive
-> this data. See the [Add Pipeline to Golioth](#add-pipeline-to-golioth)
+> [!NOTE]
+> Your Golioth project must have a Pipeline enabled to receive this
+> data. See the [Add Pipeline to Golioth](#add-pipeline-to-golioth)
 > section below.
 
 ### Stateful Data (LightDB State)
@@ -113,9 +114,10 @@ This application includes the ability to perform Over-the-Air (OTA)
 firmware updates. To do so, you need a binary compiled with a different
 version number than what is currently running on the device.
 
-> Note: if a newer release is available than what your device is
-> currently running you, may download the pre-compiled binary that ends
-> in `_update.bin` and use it in step 2 below.
+> [!NOTE]
+> If a newer release is available than what your device is currently
+> running, you may download the pre-compiled binary that ends in
+> `_update.bin` and use it in step 2 below.
 
 1. Update the version number in the `VERSION` file and perform a
    pristine (important) build to incorporate the version change.
@@ -167,6 +169,7 @@ this pipeline entry.
 
 ## Local set up
 
+> [!IMPORTANT]
 > Do not clone this repo using git. Zephyr's `west` meta tool should be
 > used to set up your local workspace.
 
@@ -205,6 +208,7 @@ Prior to building, update `VERSION` file to reflect the firmware version
 number you want to assign to this build. Then run the following commands
 to build and program the firmware onto the device.
 
+> [!WARNING]
 > You must perform a pristine build (use `-p` or remove the `build`
 > directory) after changing the firmware version number in the `VERSION`
 > file for the change to take effect.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ reference design's name.
 - Golioth Aludel Elixir
 - Golioth Aludel Mini
 
+### Additional Sensors/Components
+
+The Reference Design Template doesn't require any additional sensors or
+components.
+
 ## Golioth Features
 
 This app currently implements Over-the-Air (OTA) firmware updates,

--- a/README.md
+++ b/README.md
@@ -106,16 +106,26 @@ But default the state values will be `0` and `1`. Try updating the
 ## OTA Firmware Update
 
 This application includes the ability to perform Over-the-Air (OTA)
-firmware updates:
+firmware updates. To do so, you need a binary compiled with a different
+version number than what is currently running on the device.
 
-1.  Update the version number in the
-    <span class="title-ref">VERSION</span> file and perform a pristine
-    (important) build to incorporate the version change.
-2.  Upload the
-    <span class="title-ref">build/app/zephyr/zephyr.signed.bin</span>
-    file as an artifact for your Golioth project using
-    <span class="title-ref">main</span> as the package name.
-3.  Create and roll out a release based on this artifact.
+> Note: if a newer release is available than what your device is
+> currently running you, may download the pre-compiled binary that ends
+> in `_update.bin` and use it in step 2 below.
+
+1. Update the version number in the `VERSION` file and perform a
+   pristine (important) build to incorporate the version change.
+2. Upload the `build/app/zephyr/zephyr.signed.bin` file as a Package for
+   your Golioth project.
+
+   - Use `main` as the package name.
+   - Use the same version number from step 1.
+
+3. Create a Cohort and add your device to it.
+4. Create a Deployment for your Cohort using the package name and
+   version number from step 2.
+5. Devices in your Cohort will automatically upgrade to the most
+   recently deployed firmware.
 
 Visit [the Golioth Docs OTA Firmware Upgrade
 page](https://docs.golioth.io/firmware/golioth-firmware-sdk/firmware-upgrade/firmware-upgrade)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Overview
+# Golioth Reference Design Template
 
 The Reference Design Template demonstrates Golioth Device Management and
 Data Routing. The application connects to Golioth, streams time-series

--- a/README.md
+++ b/README.md
@@ -279,3 +279,8 @@ git merge template_v1.0.0
 git add resolved_files
 git commit
 ```
+
+## Have Questions?
+
+Please get in touch with Golioth engineers by starting a new thread on
+the [Golioth Forum](https://forum.golioth.io/).


### PR DESCRIPTION
Favor information first, and directions second. This make it easier to first peruse the README to understand what the app does, and second to build and run it for yourself.

I plan to squash all of these commits into one, along with #116 before merging so that these changes can be cherry-picked from descendant reference designs.

Resolves https://github.com/golioth/devrel-issue-tracker/issues/521
Resolves https://github.com/golioth/devrel-issue-tracker/issues/520