### PR TITLE
README: overhaul for uniformity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-# Overview
+# Golioth Reference Design Template
+
+The Reference Design Template demonstrates Golioth Device Management and
+Data Routing. The application connects to Golioth, streams time-series
+data to simulate senor readings, and sends Log messages to the cloud.
+From the Golioth web console you may deploy OTA firmware updates, adjust
+device Settings, and issue Remote Procedure Calls (RPCs).
+
+Business use cases and hardware build details for Golioth Reference
+Designs are available on the [Golioth Projects
+site](https://projects.golioth.io/).
 
 Use this repo as a template when beginning work on a new Golioth
 Reference Design. It is set up as a standalone repository, with all
@@ -6,65 +16,142 @@ Golioth features implemented in basic form. Search the project for the
 word `template` and `rd_template` and update those occurrences with your
 reference design's name.
 
-# Local set up
+## Supported Hardware
 
-> Do not clone this repo using git. Zephyr's `west` meta tool should be
-> used to set up your local workspace.
+- Nordic nRF9160-DK
+- Golioth Aludel Elixir
+- Golioth Aludel Mini
 
-## Install the Python virtual environment (recommended)
+### Additional Sensors/Components
 
-``` shell
-cd ~
-mkdir golioth-reference-design-template
-python -m venv golioth-reference-design-template/.venv
-source golioth-reference-design-template/.venv/bin/activate
-pip install wheel west ecdsa
+The Reference Design Template doesn't require any additional sensors or
+components.
+
+## Golioth Features
+
+This app currently implements Over-the-Air (OTA) firmware updates,
+Settings Service, Logging, RPC, and time-series Stream data, and LightDB
+State data.
+
+### Settings Service
+
+The following settings should be set in the Device Settings menu of the
+[Golioth Console](https://console.golioth.io).
+
+  - `LOOP_DELAY_S`
+    Adjusts the delay between sensor readings. Set to an integer value
+    (seconds).
+
+    Default value is `60` seconds.
+
+### Remote Procedure Call (RPC) Service
+
+The following RPCs can be initiated in the Remote Procedure Call menu of
+the [Golioth Console](https://console.golioth.io).
+
+  - `get_network_info`
+    Query and return network information.
+
+  - `reboot`
+    Reboot the system.
+
+  - `set_log_level`
+    Set the log level.
+
+    The method takes a single parameter which can be one of the
+    following integer values:
+
+      - `0`: `LOG_LEVEL_NONE`
+      - `1`: `LOG_LEVEL_ERR`
+      - `2`: `LOG_LEVEL_WRN`
+      - `3`: `LOG_LEVEL_INF`
+      - `4`: `LOG_LEVEL_DBG`
+
+### Time-Series Stream data
+
+Sensor readings are simulated using an up-counting timer. The value is
+periodically sent to the `sensor/counter` path of the Golioth Stream
+service.
+
+``` json
+{
+  "counter": 1
+}
 ```
 
-## Use `west` to initialize and install
+If your board includes a battery, voltage and level readings
+will be sent to the `battery` path.
 
-``` shell
-cd ~/golioth-reference-design-template
-west init -m git@github.com:golioth/reference-design-template.git .
-west update
-west zephyr-export
-pip install -r deps/zephyr/scripts/requirements.txt
+> [!NOTE]
+> Your Golioth project must have a Pipeline enabled to receive this
+> data. See the [Add Pipeline to Golioth](#add-pipeline-to-golioth)
+> section below.
+
+### Stateful Data (LightDB State)
+
+The concept of Digital Twin is demonstrated with the LightDB State
+`example_int0` and `example_int1` variables that are subpaths of the
+`desired` and `state` paths.
+
+  - `desired` values may be changed from the cloud side. The device will
+    recognize these, validate them for \[0..65535\] bounding, and then
+    reset these values to `-1`
+  - `state` values will be updated by the device to reflect the device's
+    actual stored value. The cloud may read the `state` endpoints to
+    determine device status. In this arrangement, only the device
+    should ever write to the `state` endpoints.
+
+``` json
+{
+  "desired": {
+    "example_int0": -1,
+    "example_int1": -1
+  },
+  "state": {
+    "example_int0": 0,
+    "example_int1": 1
+  }
+}
 ```
 
-# Building the application
+But default the state values will be `0` and `1`. Try updating the
+`desired` values and observe how the device updates its state.
 
-Build the Zephyr sample application for the [Nordic nRF9160
-DK](https://www.nordicsemi.com/Products/Development-hardware/nrf9160-dk)
-(`nrf9160dk_nrf9160_ns`) from the top level of your project. After a
-successful build you will see a new `build` directory. Note that any
-changes (and git commits) to the project itself will be inside the `app`
-folder. The `build` and `deps` directories being one level higher
-prevents the repo from cataloging all of the changes to the dependencies
-and the build (so no `.gitignore` is needed).
+### OTA Firmware Update
 
-Prior to building, update `VERSION` file to reflect the firmware version
-number you want to assign to this build. Then run the following commands
-to build and program the firmware onto the device.
+This application includes the ability to perform Over-the-Air (OTA)
+firmware updates. To do so, you need a binary compiled with a different
+version number than what is currently running on the device.
 
-> You must perform a pristine build (use `-p` or remove the `build`
-> directory) after changing the firmware version number in the `VERSION`
-> file for the change to take effect.
+> [!NOTE]
+> If a newer release is available than what your device is currently
+> running, you may download the pre-compiled binary that ends in
+> `_update.bin` and use it in step 2 below.
 
-``` text
-$ (.venv) west build -p -b nrf9160dk/nrf9160/ns --sysbuild app
-$ (.venv) west flash
-```
+1. Update the version number in the `VERSION` file and perform a
+   pristine (important) build to incorporate the version change.
+2. Upload the `build/app/zephyr/zephyr.signed.bin` file as a Package for
+   your Golioth project.
 
-Configure PSK-ID and PSK using the device shell based on your Golioth
-credentials and reboot:
+   - Use `main` as the package name.
+   - Use the same version number from step 1.
 
-``` text
-uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
-uart:~$ settings set golioth/psk <my-psk>
-uart:~$ kernel reboot cold
-```
+3. Create a Cohort and add your device to it.
+4. Create a Deployment for your Cohort using the package name and
+   version number from step 2.
+5. Devices in your Cohort will automatically upgrade to the most
+   recently deployed firmware.
 
-# Add Pipeline to Golioth
+Visit [the Golioth Docs OTA Firmware Upgrade
+page](https://docs.golioth.io/firmware/golioth-firmware-sdk/firmware-upgrade/firmware-upgrade)
+for more info.
+
+### Further Information in Header Files
+
+Please refer to the comments in each header file for a
+service-by-service explanation of this template.
+
+## Add Pipeline to Golioth
 
 Golioth uses [Pipelines](https://docs.golioth.io/data-routing) to route
 stream data. This gives you flexibility to change your data routing
@@ -89,129 +176,67 @@ LightDB Stream and may be viewed using the web console. You may change
 this behavior at any time without updating firmware simply by editing
 this pipeline entry.
 
-# Golioth Features
+## Local set up
 
-This app currently implements Over-the-Air (OTA) firmware updates,
-Settings Service, Logging, RPC, and both LightDB State and LightDB
-Stream data.
+> [!IMPORTANT]
+> Do not clone this repo using git. Zephyr's `west` meta tool should be
+> used to set up your local workspace.
 
-## Settings Service
+### Install the Python virtual environment (recommended)
 
-The following settings should be set in the Device Settings menu of the
-[Golioth Console](https://console.golioth.io).
+``` shell
+cd ~
+mkdir golioth-reference-design-template
+python -m venv golioth-reference-design-template/.venv
+source golioth-reference-design-template/.venv/bin/activate
+pip install wheel west ecdsa
+```
 
-  - `LOOP_DELAY_S`
-    Adjusts the delay between sensor readings. Set to an integer value
-    (seconds).
+### Use `west` to initialize and install
 
-    Default value is `60` seconds.
+``` shell
+cd ~/golioth-reference-design-template
+west init -m git@github.com:golioth/reference-design-template.git .
+west update
+west zephyr-export
+pip install -r deps/zephyr/scripts/requirements.txt
+```
 
-## Remote Procedure Call (RPC) Service
+## Building the application
 
-The following RPCs can be initiated in the Remote Procedure Call menu of
-the [Golioth Console](https://console.golioth.io).
-
-  - `get_network_info`
-    Query and return network information.
-
-  - `reboot`
-    Reboot the system.
-
-  - `set_log_level`
-    Set the log level.
-
-    The method takes a single parameter which can be one of the
-    following integer values:
-
-      - `0`: `LOG_LEVEL_NONE`
-      - `1`: `LOG_LEVEL_ERR`
-      - `2`: `LOG_LEVEL_WRN`
-      - `3`: `LOG_LEVEL_INF`
-      - `4`: `LOG_LEVEL_DBG`
-
-## LightDB State and LightDB Stream data
-
-### Time-Series Data (LightDB Stream)
-
-An up-counting timer is periodically sent to the `sensor/counter`
-endpoint of the LightDB Stream service to simulate sensor data. If your
-board includes a battery, voltage and level readings will be sent to the
-`battery` endpoint.
-
-### Stateful Data (LightDB State)
-
-The concept of Digital Twin is demonstrated with the LightDB State
-`example_int0` and `example_int1` variables that are members of the
-`desired` and `state` endpoints.
-
-  - `desired` values may be changed from the cloud side. The device will
-    recognize these, validate them for \[0..65535\] bounding, and then
-    reset these endpoints to `-1`
-  - `state` values will be updated by the device whenever a valid value
-    is received from the `desired` endpoints. The cloud may read the
-    `state` endpoints to determine device status, but only the device
-    should ever write to the `state` endpoints.
-
-## Further Information in Header Files
-
-Please refer to the comments in each header file for a
-service-by-service explanation of this template.
-
-# Hardware Variations
-
-This reference design may be built for a variety of different boards.
+Build the Zephyr sample application for the [Nordic nRF9160
+DK](https://www.nordicsemi.com/Products/Development-hardware/nrf9160-dk)
+(`nrf9160dk_nrf9160_ns`) from the top level of your project. After a
+successful build you will see a new `build` directory. Note that any
+changes (and git commits) to the project itself will be inside the `app`
+folder. The `build` and `deps` directories being one level higher
+prevents the repo from cataloging all of the changes to the dependencies
+and the build (so no `.gitignore` is needed).
 
 Prior to building, update `VERSION` file to reflect the firmware version
 number you want to assign to this build. Then run the following commands
 to build and program the firmware onto the device.
 
-## Golioth Aludel Mini
-
-This reference design may be built for the Golioth Aludel Mini board.
+> [!WARNING]
+> You must perform a pristine build (use `-p` or remove the `build`
+> directory) after changing the firmware version number in the `VERSION`
+> file for the change to take effect.
 
 ``` text
-$ (.venv) west build -p -b aludel_mini/nrf9160/ns --sysbuild app
+$ (.venv) west build -p -b nrf9160dk/nrf9160/ns --sysbuild app
 $ (.venv) west flash
 ```
 
-## Golioth Aludel Elixir
-
-This reference design may be built for the Golioth Aludel Elixir board.
-By default this will build for the latest hardware revision of this
-board.
+Configure PSK-ID and PSK using the device shell based on your Golioth
+credentials and reboot:
 
 ``` text
-$ (.venv) west build -p -b aludel_elixir/nrf9160/ns --sysbuild app
-$ (.venv) west flash
+uart:~$ settings set golioth/psk-id <my-psk-id@my-project>
+uart:~$ settings set golioth/psk <my-psk>
+uart:~$ kernel reboot cold
 ```
 
-To build for a specific board revision (e.g. Rev A) add the revision
-suffix `@<rev>`.
-
-``` text
-$ (.venv) west build -p -b aludel_elixir@A/nrf9160/ns --sysbuild app
-$ (.venv) west flash
-```
-
-# OTA Firmware Update
-
-This application includes the ability to perform Over-the-Air (OTA)
-firmware updates:
-
-1.  Update the version number in the
-    <span class="title-ref">VERSION</span> file and perform a pristine
-    (important) build to incorporate the version change.
-2.  Upload the
-    <span class="title-ref">build/app/zephyr/zephyr.signed.bin</span>
-    file as an artifact for your Golioth project using
-    <span class="title-ref">main</span> as the package name.
-3.  Create and roll out a release based on this artifact.
-
-Visit [the Golioth Docs OTA Firmware Upgrade
-page](https://docs.golioth.io/firmware/golioth-firmware-sdk/firmware-upgrade/firmware-upgrade)
-for more info.
-
-# External Libraries
+## External Libraries
 
 The following code libraries are installed by default. If you are not
 using the custom hardware to which they apply, you can safely remove
@@ -226,7 +251,7 @@ calls from the C code.
     is a helper library for querying, formatting, and returning network
     connection information via Zephyr log or Golioth RPC
 
-# Using this template to start a new project
+## Using this template to start a new project
 
 Fork this template to create your own Reference Design. After checking
 out your fork, we recommend the following workflow to pull in future
@@ -254,3 +279,8 @@ git merge template_v1.0.0
 git add resolved_files
 git commit
 ```
+
+## Have Questions?
+
+Please get in touch with Golioth engineers by starting a new thread on
+the [Golioth Forum](https://forum.golioth.io/).


### PR DESCRIPTION
- add overview of functionality
- add a supported hardware overview
- move Golioth Features above Local set up
- update LightDB Stream and LightDB State
- Separate Stream from State
- Add Stream example JSON
- Add LightDB State Example JSON
- Clarify LightDB State functionality
- update OTA instructions for Packages/Cohorts/Deployments
- Move pipelines higher in the document
- Reference the pipelines section from the Stream section
- Move hardware variants lower in the document
- Simplify the hardware variants section
- rename opening section
- make all headings after the first subheadings
- properly style admonitions for GitHub
- add section for additional sensors/components
- remove hardware variations sections
- add mention of use cases and link to projects site
- add section for asking questions